### PR TITLE
Clarify SO3.slerp docstring

### DIFF
--- a/src/nanomanifold/SO3/slerp.py
+++ b/src/nanomanifold/SO3/slerp.py
@@ -8,26 +8,26 @@ from .canonicalize import canonicalize
 
 
 def slerp(q1: Float[Any, "... 4"], q2: Float[Any, "... 4"], t: Float[Any, "... N"]) -> Float[Any, "... N 4"]:
-    """Spherical linear interpolation between two quaternions representing SO(3) rotations.
+"""Spherical linear interpolation between two quaternions representing SO(3).
 
-    Performs geodesic interpolation on the SO(3) manifold, taking the shortest
-    path between two rotations. The interpolation parameter array t must have
-    values in [0, 1].
+The routine performs geodesic interpolation on the SO(3) manifold, taking the
+shortest path between two rotations after canonicalizing the inputs to the same
+hemisphere. The interpolation parameters ``t`` are typically chosen in the
+closed interval ``[0, 1]`` where ``t = 0`` returns ``q1`` and ``t = 1`` returns
+``q2``, but values outside that range are accepted and will extrapolate beyond
+the arc connecting the endpoints.
 
-    Args:
-        q1: Start quaternion in [w, x, y, z] format
-        q2: End quaternion in [w, x, y, z] format
-        t: Array of interpolation parameters in [0, 1]. Last dimension N represents
-           the number of interpolation points. For a single point, use shape [..., 1].
-           t values: 0 returns q1, 1 returns q2
+Args:
+    q1: Start quaternion in ``[w, x, y, z]`` format.
+    q2: End quaternion in ``[w, x, y, z]`` format.
+    t: Array of interpolation parameters whose last dimension ``N`` represents
+        the number of interpolation points. For a single point use shape
+        ``[..., 1]``.
 
-    Returns:
-        Interpolated quaternions with shape [..., N, 4] where N is the number of
-        interpolation points from the last dimension of t
-
-    Raises:
-        ValueError: If any t values are outside the range [0, 1]
-    """
+Returns:
+    Interpolated quaternions with shape ``[..., N, 4]`` where ``N`` is the last
+    dimension of ``t``.
+"""
     xp = get_namespace(q1)
 
     q1 = canonicalize(q1)


### PR DESCRIPTION
## Summary
- refresh the SO3.slerp docstring to describe how inputs are canonicalized and how t values are handled
- remove the outdated ValueError claim and explain that out-of-range t values extrapolate

## Testing
- not run (docstring only)


------
https://chatgpt.com/codex/tasks/task_e_68ca79200594832687602c72469ffcff