### PR TITLE
[codex] add SO3 hinge helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Supported SO3 parametrizations:
 | `canonicalize(q, convention="wxyz")`  | `(...,4) -> (...,4)`                      |
 | `to_axis_angle(q, convention="wxyz")` | `(...,4) -> (...,3)`                      |
 | `from_axis_angle(axis_angle, convention="wxyz")` | `(...,3) -> (...,4)`         |
+| `from_hinge(angles, axes, convention="wxyz")` | `(...,1), (...,3) -> (...,4)` |
+| `to_hinge(q, axes, convention="wxyz")` | `(...,4), (...,3) -> (...,1)`          |
 | `to_euler(q, convention="ZYX", quat_convention="wxyz")` | `(...,4) -> (...,3)`     |
 | `from_euler(euler, convention="ZYX", quat_convention="wxyz")` | `(...,3) -> (...,4)` |
 | `convert(x, src=..., dst=...)`        | dynamic                                   |
@@ -183,6 +185,11 @@ quat_alt = SO3.convert(euler, src="euler", dst="quat", src_convention="XYZ", dst
 quat = SO3.convert(quat_alt, src="quat", dst="quat", src_convention="xyzw", dst_convention="wxyz")
 euler = SO3.convert(rotmat, src="rotmat", dst="euler", dst_convention="ZYX")
 ```
+
+For constrained one-axis rotations, use `SO3.from_hinge` and `SO3.to_hinge`.
+The hinge helpers map `(...,1)` scalar coefficients to axis-angle vectors with
+`angles * axes`. `to_hinge` projects the principal axis-angle vector back onto
+`axes`; for unit axes this is the signed principal rotation angle.
 
 ## Backend-Explicit Mode
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nanomanifold"
-version = "0.6.1"
+version = "0.7.0"
 description = "SO3/SE3 operations on any backend"
 readme = "README.md"
 authors = [

--- a/src/nanomanifold/SO3/__init__.py
+++ b/src/nanomanifold/SO3/__init__.py
@@ -3,6 +3,7 @@ from .convert import RotationRep, convert
 from .distance import distance
 from .exp import exp
 from .hat import hat
+from .hinge import from_hinge, to_hinge
 from .identity import identity_as
 from .inverse import inverse
 from .log import log
@@ -25,6 +26,8 @@ __all__ = [
     "identity_as",
     "to_axis_angle",
     "from_axis_angle",
+    "from_hinge",
+    "to_hinge",
     "to_euler",
     "from_euler",
     "to_rotmat",

--- a/src/nanomanifold/SO3/hinge.py
+++ b/src/nanomanifold/SO3/hinge.py
@@ -1,0 +1,55 @@
+"""Helpers for one-axis SO(3) hinge rotations."""
+
+from types import ModuleType
+from typing import Any
+
+from jaxtyping import Float
+
+from nanomanifold import common
+
+from .primitives import axis_angle as axis_angle_primitives
+from .primitives.quaternion import QuaternionConvention
+
+
+def from_hinge(
+    angles: Float[Any, "... 1"],
+    axes: Float[Any, "... 3"],
+    *,
+    convention: QuaternionConvention = "wxyz",
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 4"]:
+    """Create rotations constrained to a single hinge axis.
+
+    ``axes`` are interpreted as axis-angle generators. Unit axes make ``angles``
+    physical rotation angles; non-unit axes scale the generated rotation vector.
+    """
+    if xp is None:
+        xp = common.get_namespace(angles)
+
+    assert angles.shape[-1:] == (1,), "Hinge angles must have shape (..., 1)."
+    axis_angle = angles * axes
+    return axis_angle_primitives.from_axis_angle(axis_angle, convention=convention, xp=xp)
+
+
+def to_hinge(
+    q: Float[Any, "... 4"],
+    axes: Float[Any, "... 3"],
+    *,
+    convention: QuaternionConvention = "wxyz",
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 1"]:
+    """Project an SO(3) rotation onto a single hinge axis.
+
+    The result is the least-squares coefficient of the rotation vector along
+    ``axes``. For unit axes this is the signed principal rotation angle.
+    """
+    if xp is None:
+        xp = common.get_namespace(q)
+
+    axis_angle = axis_angle_primitives.to_axis_angle(q, convention=convention, xp=xp)
+    projected = xp.sum(axis_angle * axes, axis=-1, keepdims=True)
+    axis_norm_sq = xp.sum(axes * axes, axis=-1, keepdims=True)
+    return projected / axis_norm_sq
+
+
+__all__ = ["from_hinge", "to_hinge"]

--- a/src/nanomanifold/__init__.py
+++ b/src/nanomanifold/__init__.py
@@ -1,5 +1,5 @@
 from . import SE3, SO3
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 __all__ = ["SO3", "SE3", "__version__"]

--- a/tests/test_jax_jit.py
+++ b/tests/test_jax_jit.py
@@ -84,6 +84,17 @@ def test_jit_to_axis_angle():
     compiled(_random_quat())
 
 
+def test_jit_from_hinge():
+    compiled = jax.jit(lambda angles, axes: SO3.from_hinge(angles, axes, xp=jnp))
+    compiled(jnp.array([[0.1], [-0.2]]), jnp.array([0.0, 0.0, 1.0]))
+
+
+def test_jit_to_hinge():
+    axes = jnp.array([0.0, 0.0, 1.0])
+    compiled = jax.jit(lambda q: SO3.to_hinge(q, axes, xp=jnp))
+    compiled(_random_quat())
+
+
 def test_jit_from_rotmat():
     compiled = jax.jit(lambda R: SO3.from_rotmat(R, xp=jnp))
     compiled(jnp.broadcast_to(jnp.eye(3), (2, 3, 3)))

--- a/tests/test_so3_hinge.py
+++ b/tests/test_so3_hinge.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pytest
+from conftest import ATOL, TEST_BACKENDS, TEST_PASS_XP, TEST_PRECISIONS, get_xp_kwargs
+
+from nanomanifold import SO3
+from nanomanifold.common import get_namespace_by_name
+
+
+@pytest.mark.parametrize("backend", TEST_BACKENDS)
+@pytest.mark.parametrize("precision", TEST_PRECISIONS)
+@pytest.mark.parametrize("pass_xp", TEST_PASS_XP)
+def test_from_hinge_matches_axis_angle_to_quat_conversion(backend, precision, pass_xp):
+    xp = get_namespace_by_name(backend)
+    angles = xp.asarray(np.array([[0.1], [-0.2], [0.3]], dtype=f"float{precision}"))
+    axes = xp.asarray(np.array([0.0, 0.0, 1.0], dtype=f"float{precision}"))
+    xp_kwargs = get_xp_kwargs(backend, pass_xp)
+
+    result = SO3.from_hinge(angles, axes, **xp_kwargs)
+    expected = SO3.convert(angles * axes, src="axis_angle", dst="quat", **xp_kwargs)
+
+    assert result.dtype == expected.dtype
+    assert result.shape == expected.shape
+    assert np.allclose(np.array(result), np.array(expected), atol=ATOL[precision])
+
+
+@pytest.mark.parametrize("backend", TEST_BACKENDS)
+@pytest.mark.parametrize("precision", TEST_PRECISIONS)
+@pytest.mark.parametrize("pass_xp", TEST_PASS_XP)
+def test_from_hinge_broadcasts_batch_axes(backend, precision, pass_xp):
+    xp = get_namespace_by_name(backend)
+    angles = xp.asarray(np.array([[0.1], [-0.2], [0.3]], dtype=f"float{precision}"))
+    axes = xp.asarray(np.array([[0.0, 1.0, 0.0]], dtype=f"float{precision}"))
+    xp_kwargs = get_xp_kwargs(backend, pass_xp)
+
+    result = SO3.from_hinge(angles, axes, **xp_kwargs)
+    expected = SO3.convert(angles * axes, src="axis_angle", dst="quat", **xp_kwargs)
+
+    assert result.dtype == expected.dtype
+    assert result.shape == expected.shape
+    assert np.allclose(np.array(result), np.array(expected), atol=ATOL[precision])
+
+
+@pytest.mark.parametrize("backend", TEST_BACKENDS)
+@pytest.mark.parametrize("precision", TEST_PRECISIONS)
+@pytest.mark.parametrize("pass_xp", TEST_PASS_XP)
+def test_to_hinge_roundtrips_from_hinge_for_nonunit_axes(backend, precision, pass_xp):
+    xp = get_namespace_by_name(backend)
+    angles = xp.asarray(np.array([[0.1], [-0.2], [0.3]], dtype=f"float{precision}"))
+    axes = xp.asarray(np.array([0.0, 0.0, 2.0], dtype=f"float{precision}"))
+    xp_kwargs = get_xp_kwargs(backend, pass_xp)
+
+    rotation = SO3.from_hinge(angles, axes, **xp_kwargs)
+    recovered = SO3.to_hinge(rotation, axes, **xp_kwargs)
+
+    assert recovered.dtype == angles.dtype
+    assert recovered.shape == angles.shape
+    assert np.allclose(np.array(recovered), np.array(angles), atol=ATOL[precision])
+
+
+def test_to_hinge_projects_axis_angle_to_requested_axis():
+    axis_angle = np.array([0.3, 0.4, 0.0], dtype=np.float32)
+    rotation = SO3.convert(axis_angle, src="axis_angle", dst="quat")
+    axis = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+
+    angle = SO3.to_hinge(rotation, axis)
+
+    assert angle.shape == (1,)
+    assert np.allclose(np.array(angle), np.array([0.3], dtype=np.float32), atol=ATOL[32])
+
+
+def test_to_hinge_returns_trailing_singleton():
+    angles = np.array([[0.1], [-0.2], [0.3]], dtype=np.float32)
+    axes = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+    rotation = SO3.from_hinge(angles, axes)
+
+    recovered = SO3.to_hinge(rotation, axes)
+
+    assert recovered.shape == (3, 1)
+    assert np.allclose(recovered, angles, atol=ATOL[32])
+
+
+def test_hinge_helpers_accept_quaternion_convention():
+    angles = np.array([[0.1], [-0.2], [0.3]], dtype=np.float32)
+    axes = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+    rotation = SO3.from_hinge(angles, axes, convention="xyzw")
+
+    recovered = SO3.to_hinge(rotation, axes, convention="xyzw")
+
+    assert np.allclose(recovered, angles, atol=ATOL[32])

--- a/tests/test_torch_compile.py
+++ b/tests/test_torch_compile.py
@@ -91,6 +91,24 @@ def test_compile_to_axis_angle():
     compiled(_random_quat())
 
 
+def test_compile_from_hinge():
+    def f(angles, axes):
+        return SO3.from_hinge(angles, axes, xp=torch)
+
+    compiled = torch.compile(f, fullgraph=True)
+    compiled(torch.tensor([[0.1], [-0.2]]), torch.tensor([0.0, 0.0, 1.0]))
+
+
+def test_compile_to_hinge():
+    axes = torch.tensor([0.0, 0.0, 1.0])
+
+    def f(q):
+        return SO3.to_hinge(q, axes, xp=torch)
+
+    compiled = torch.compile(f, fullgraph=True)
+    compiled(_random_quat())
+
+
 def test_compile_from_rotmat():
     def f(R):
         return SO3.from_rotmat(R, xp=torch)

--- a/uv.lock
+++ b/uv.lock
@@ -379,7 +379,7 @@ wheels = [
 
 [[package]]
 name = "nanomanifold"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "jaxtyping", version = "0.3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Adds first-class SO3 hinge helpers for constrained one-axis rotations, shaped like the existing SO3 primitive helpers:

- `SO3.from_hinge(angles, axes, convention="wxyz", xp=None)` maps `(..., 1)` hinge coefficients and `(..., 3)` axes to quaternions with shape `(..., 4)`.
- `SO3.to_hinge(q, axes, convention="wxyz", xp=None)` projects quaternions back to `(..., 1)` hinge coefficients.
- Exports the helpers from `nanomanifold.SO3` and documents the API in the README.
- Bumps the package version to `0.7.0`.
- Adds backend, shape, convention, JAX JIT, and Torch compile coverage.

## Notes

The implementation stays at the primitive layer by composing the existing axis-angle helpers. `to_hinge` uses a least-squares coefficient, `dot(axis_angle, axes) / dot(axes, axes)`; unit axes return the signed principal hinge angle, and non-unit axes round-trip as coefficients with `from_hinge`.

## Validation

- `uv run ruff check .`
- `uv run pytest`

Latest full test result: `11329 passed, 70 skipped`.