### PR TITLE
[codex] add SO3 hinge pairwise conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,37 +139,49 @@ Supported SO3 parametrizations:
 ## Pairwise Conversions (`SO3.conversions`)
 
 Convert directly between any two rotation representations without going through
-quaternions manually. All 30 pairwise functions follow the naming pattern
+quaternions manually. Pairwise functions follow the naming pattern
 `from_{source}_to_{target}`.
 
-Representations: `axis_angle`, `euler`, `matrix`, `rotmat`, `quat`, `sixd`.
+Representations: `axis_angle`, `euler`, `hinge`, `matrix`, `rotmat`, `quat`, `sixd`.
 Quaternion conventions use lowercase `convention="wxyz"` or `convention="xyzw"`.
+Hinge conversions take `axes` as a required second argument.
 
 | Function                                                        | Signature                   |
 | --------------------------------------------------------------- | --------------------------- |
 | `SO3.conversions.from_axis_angle_to_rotmat(aa)`                | `(...,3) -> (...,3,3)`      |
 | `SO3.conversions.from_axis_angle_to_euler(aa, convention)`      | `(...,3) -> (...,3)`        |
+| `SO3.conversions.from_axis_angle_to_hinge(aa, axes)`            | `(...,3), (...,3) -> (...,1)` |
 | `SO3.conversions.from_axis_angle_to_quat(aa, convention="wxyz")` | `(...,3) -> (...,4)`      |
 | `SO3.conversions.from_axis_angle_to_sixd(aa)`                   | `(...,3) -> (...,6)`        |
 | `SO3.conversions.from_euler_to_axis_angle(e, convention)`       | `(...,3) -> (...,3)`        |
+| `SO3.conversions.from_euler_to_hinge(e, axes, convention)`      | `(...,3), (...,3) -> (...,1)` |
 | `SO3.conversions.from_euler_to_rotmat(e, convention)`          | `(...,3) -> (...,3,3)`      |
 | `SO3.conversions.from_euler_to_quat(e, src_convention="ZYX", dst_convention="wxyz")` | `(...,3) -> (...,4)` |
 | `SO3.conversions.from_euler_to_sixd(e, convention)`             | `(...,3) -> (...,6)`        |
+| `SO3.conversions.from_hinge_to_axis_angle(angles, axes)`        | `(...,1), (...,3) -> (...,3)` |
+| `SO3.conversions.from_hinge_to_euler(angles, axes, convention)` | `(...,1), (...,3) -> (...,3)` |
+| `SO3.conversions.from_hinge_to_rotmat(angles, axes)`            | `(...,1), (...,3) -> (...,3,3)` |
+| `SO3.conversions.from_hinge_to_quat(angles, axes, convention="wxyz")` | `(...,1), (...,3) -> (...,4)` |
+| `SO3.conversions.from_hinge_to_sixd(angles, axes)`              | `(...,1), (...,3) -> (...,6)` |
 | `SO3.conversions.from_rotmat_to_axis_angle(R)`                 | `(...,3,3) -> (...,3)`      |
+| `SO3.conversions.from_rotmat_to_hinge(R, axes)`                | `(...,3,3), (...,3) -> (...,1)` |
 | `SO3.conversions.from_rotmat_to_euler(R, convention)`          | `(...,3,3) -> (...,3)`      |
 | `SO3.conversions.from_rotmat_to_quat(R, convention="wxyz")`   | `(...,3,3) -> (...,4)`      |
 | `SO3.conversions.from_rotmat_to_sixd(R)`                      | `(...,3,3) -> (...,6)`      |
 | `SO3.conversions.from_matrix_to_rotmat(M, mode="svd")`       | `(...,3,3) -> (...,3,3)`    |
 | `SO3.conversions.from_matrix_to_axis_angle(M, mode="svd")` | `(...,3,3) -> (...,3)` |
+| `SO3.conversions.from_matrix_to_hinge(M, axes, mode="svd")` | `(...,3,3), (...,3) -> (...,1)` |
 | `SO3.conversions.from_matrix_to_euler(R, convention, mode="svd")` | `(...,3,3) -> (...,3)` |
 | `SO3.conversions.from_matrix_to_quat(R, convention="wxyz", mode="svd")` | `(...,3,3) -> (...,4)` |
 | `SO3.conversions.from_matrix_to_sixd(R, mode="svd")`       | `(...,3,3) -> (...,6)` |
 | `SO3.conversions.from_quat_to_axis_angle(q, convention="wxyz")` | `(...,4) -> (...,3)`       |
+| `SO3.conversions.from_quat_to_hinge(q, axes, convention="wxyz")` | `(...,4), (...,3) -> (...,1)` |
 | `SO3.conversions.from_quat_to_euler(q, src_convention="wxyz", dst_convention="ZYX")` | `(...,4) -> (...,3)` |
 | `SO3.conversions.from_quat_to_rotmat(q, convention="wxyz")`    | `(...,4) -> (...,3,3)`      |
 | `SO3.conversions.from_quat_to_quat(q, src_convention="wxyz", dst_convention="xyzw")` | `(...,4) -> (...,4)` |
 | `SO3.conversions.from_quat_to_sixd(q, convention="wxyz")`      | `(...,4) -> (...,6)`        |
 | `SO3.conversions.from_sixd_to_axis_angle(sixd)`                 | `(...,6) -> (...,3)`        |
+| `SO3.conversions.from_sixd_to_hinge(sixd, axes)`                | `(...,6), (...,3) -> (...,1)` |
 | `SO3.conversions.from_sixd_to_euler(sixd, convention)`          | `(...,6) -> (...,3)`        |
 | `SO3.conversions.from_sixd_to_rotmat(sixd)`                    | `(...,6) -> (...,3,3)`      |
 | `SO3.conversions.from_sixd_to_quat(sixd, convention="wxyz")`    | `(...,6) -> (...,4)`        |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nanomanifold"
-version = "0.7.0"
+version = "0.7.1"
 description = "SO3/SE3 operations on any backend"
 readme = "README.md"
 authors = [

--- a/src/nanomanifold/SO3/conversions/conversions.py
+++ b/src/nanomanifold/SO3/conversions/conversions.py
@@ -57,6 +57,19 @@ def from_axis_angle_to_euler(
     return _to_euler(_from_axis_angle(axis_angle, xp=xp), convention=convention, xp=xp)
 
 
+def from_axis_angle_to_hinge(
+    axis_angle: Float[Any, "... 3"],
+    axes: Float[Any, "... 3"],
+    *,
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 1"]:
+    if xp is None:
+        xp = get_namespace(axis_angle)
+    projected = xp.sum(axis_angle * axes, axis=-1, keepdims=True)
+    axis_norm_sq = xp.sum(axes * axes, axis=-1, keepdims=True)
+    return projected / axis_norm_sq
+
+
 def from_axis_angle_to_rotmat(axis_angle: Float[Any, "... 3"], *, xp: ModuleType | None = None) -> Float[Any, "... 3 3"]:
     if xp is None:
         xp = get_namespace(axis_angle)
@@ -82,6 +95,18 @@ def from_euler_to_axis_angle(
 ) -> Float[Any, "... 3"]:
     assert convention in _EULER_CONVENTIONS, "Invalid Euler convention."
     return _to_axis_angle(_from_euler(euler, convention=convention, xp=xp), xp=xp)
+
+
+def from_euler_to_hinge(
+    euler: Float[Any, "... 3"],
+    axes: Float[Any, "... 3"],
+    *,
+    convention: EulerConvention = "ZYX",
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 1"]:
+    assert convention in _EULER_CONVENTIONS, "Invalid Euler convention."
+    axis_angle = from_euler_to_axis_angle(euler, convention=convention, xp=xp)
+    return from_axis_angle_to_hinge(axis_angle, axes, xp=xp)
 
 
 def from_euler_to_euler(
@@ -122,8 +147,71 @@ def from_euler_to_sixd(
     return from_rotmat_to_sixd(from_euler_to_rotmat(euler, convention=convention, xp=xp), xp=xp)
 
 
+def from_hinge_to_axis_angle(
+    angles: Float[Any, "... 1"],
+    axes: Float[Any, "... 3"],
+    *,
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 3"]:
+    assert angles.shape[-1:] == (1,), "Hinge angles must have shape (..., 1)."
+    return angles * axes
+
+
+def from_hinge_to_euler(
+    angles: Float[Any, "... 1"],
+    axes: Float[Any, "... 3"],
+    *,
+    convention: EulerConvention = "ZYX",
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 3"]:
+    assert convention in _EULER_CONVENTIONS, "Invalid Euler convention."
+    axis_angle = from_hinge_to_axis_angle(angles, axes, xp=xp)
+    return from_axis_angle_to_euler(axis_angle, convention=convention, xp=xp)
+
+
+def from_hinge_to_rotmat(
+    angles: Float[Any, "... 1"],
+    axes: Float[Any, "... 3"],
+    *,
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 3 3"]:
+    axis_angle = from_hinge_to_axis_angle(angles, axes, xp=xp)
+    return from_axis_angle_to_rotmat(axis_angle, xp=xp)
+
+
+def from_hinge_to_quat(
+    angles: Float[Any, "... 1"],
+    axes: Float[Any, "... 3"],
+    *,
+    convention: QuaternionConvention = "wxyz",
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 4"]:
+    assert convention in ("wxyz", "xyzw"), "Quaternion convention must be 'wxyz' or 'xyzw'."
+    axis_angle = from_hinge_to_axis_angle(angles, axes, xp=xp)
+    return from_axis_angle_to_quat(axis_angle, convention=convention, xp=xp)
+
+
+def from_hinge_to_sixd(
+    angles: Float[Any, "... 1"],
+    axes: Float[Any, "... 3"],
+    *,
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 6"]:
+    return from_rotmat_to_sixd(from_hinge_to_rotmat(angles, axes, xp=xp), xp=xp)
+
+
 def from_rotmat_to_axis_angle(rotmat: Float[Any, "... 3 3"], *, xp: ModuleType | None = None) -> Float[Any, "... 3"]:
     return _to_axis_angle(_from_rotmat(rotmat, xp=xp), xp=xp)
+
+
+def from_rotmat_to_hinge(
+    rotmat: Float[Any, "... 3 3"],
+    axes: Float[Any, "... 3"],
+    *,
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 1"]:
+    axis_angle = from_rotmat_to_axis_angle(rotmat, xp=xp)
+    return from_axis_angle_to_hinge(axis_angle, axes, xp=xp)
 
 
 def from_rotmat_to_euler(
@@ -158,6 +246,17 @@ def from_matrix_to_rotmat(matrix: Float[Any, "... 3 3"], *, mode: str = "svd", x
 def from_matrix_to_axis_angle(matrix: Float[Any, "... 3 3"], *, mode: str = "svd", xp: ModuleType | None = None) -> Float[Any, "... 3"]:
     rotmat = from_matrix_to_rotmat(matrix, mode=mode, xp=xp)
     return from_rotmat_to_axis_angle(rotmat, xp=xp)
+
+
+def from_matrix_to_hinge(
+    matrix: Float[Any, "... 3 3"],
+    axes: Float[Any, "... 3"],
+    *,
+    mode: str = "svd",
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 1"]:
+    axis_angle = from_matrix_to_axis_angle(matrix, mode=mode, xp=xp)
+    return from_axis_angle_to_hinge(axis_angle, axes, xp=xp)
 
 
 def from_matrix_to_euler(
@@ -197,6 +296,18 @@ def from_quat_to_axis_angle(
 ) -> Float[Any, "... 3"]:
     assert convention in ("wxyz", "xyzw"), "Quaternion convention must be 'wxyz' or 'xyzw'."
     return _to_axis_angle(_from_quat(quat, convention=convention, xp=xp), xp=xp)
+
+
+def from_quat_to_hinge(
+    quat: Float[Any, "... 4"],
+    axes: Float[Any, "... 3"],
+    *,
+    convention: QuaternionConvention = "wxyz",
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 1"]:
+    assert convention in ("wxyz", "xyzw"), "Quaternion convention must be 'wxyz' or 'xyzw'."
+    axis_angle = from_quat_to_axis_angle(quat, convention=convention, xp=xp)
+    return from_axis_angle_to_hinge(axis_angle, axes, xp=xp)
 
 
 def from_quat_to_euler(
@@ -249,6 +360,16 @@ def from_sixd_to_axis_angle(sixd: Float[Any, "... 6"], *, xp: ModuleType | None 
     return _to_axis_angle(_from_sixd(sixd, xp=xp), xp=xp)
 
 
+def from_sixd_to_hinge(
+    sixd: Float[Any, "... 6"],
+    axes: Float[Any, "... 3"],
+    *,
+    xp: ModuleType | None = None,
+) -> Float[Any, "... 1"]:
+    axis_angle = from_sixd_to_axis_angle(sixd, xp=xp)
+    return from_axis_angle_to_hinge(axis_angle, axes, xp=xp)
+
+
 def from_sixd_to_euler(
     sixd: Float[Any, "... 6"], *, convention: EulerConvention = "ZYX", xp: ModuleType | None = None
 ) -> Float[Any, "... 3"]:
@@ -274,29 +395,40 @@ def from_sixd_to_quat(
 
 __all__ = [
     "from_axis_angle_to_euler",
+    "from_axis_angle_to_hinge",
     "from_axis_angle_to_rotmat",
     "from_axis_angle_to_quat",
     "from_axis_angle_to_sixd",
     "from_euler_to_axis_angle",
+    "from_euler_to_hinge",
     "from_euler_to_euler",
     "from_euler_to_rotmat",
     "from_euler_to_quat",
     "from_euler_to_sixd",
+    "from_hinge_to_axis_angle",
+    "from_hinge_to_euler",
+    "from_hinge_to_rotmat",
+    "from_hinge_to_quat",
+    "from_hinge_to_sixd",
     "from_rotmat_to_axis_angle",
+    "from_rotmat_to_hinge",
     "from_rotmat_to_euler",
     "from_rotmat_to_quat",
     "from_rotmat_to_sixd",
     "from_matrix_to_rotmat",
     "from_matrix_to_axis_angle",
+    "from_matrix_to_hinge",
     "from_matrix_to_euler",
     "from_matrix_to_quat",
     "from_matrix_to_sixd",
     "from_quat_to_axis_angle",
+    "from_quat_to_hinge",
     "from_quat_to_euler",
     "from_quat_to_rotmat",
     "from_quat_to_quat",
     "from_quat_to_sixd",
     "from_sixd_to_axis_angle",
+    "from_sixd_to_hinge",
     "from_sixd_to_euler",
     "from_sixd_to_rotmat",
     "from_sixd_to_quat",

--- a/src/nanomanifold/__init__.py
+++ b/src/nanomanifold/__init__.py
@@ -1,5 +1,5 @@
 from . import SE3, SO3
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 __all__ = ["SO3", "SE3", "__version__"]

--- a/tests/test_jax_jit.py
+++ b/tests/test_jax_jit.py
@@ -39,8 +39,8 @@ def _conv_input(rep: str):
 
 
 _CONV_REPS = ["axis_angle", "euler", "matrix", "rotmat", "quat", "sixd"]
-_PAIRWISE_SOURCE_REPS = ["axis_angle", "euler", "matrix", "rotmat", "quat", "sixd"]
-_PAIRWISE_TARGET_REPS = ["axis_angle", "euler", "rotmat", "quat", "sixd"]
+_PAIRWISE_SOURCE_REPS = ["axis_angle", "euler", "hinge", "matrix", "rotmat", "quat", "sixd"]
+_PAIRWISE_TARGET_REPS = ["axis_angle", "euler", "hinge", "rotmat", "quat", "sixd"]
 _CONV_PAIRS = [(s, t) for s in _PAIRWISE_SOURCE_REPS for t in _PAIRWISE_TARGET_REPS if s != t]
 _DYNAMIC_CONV_CASES = [
     ("axis_angle", "rotmat"),
@@ -68,6 +68,8 @@ def _pairwise_input(rep: str):
         return SO3.to_quat(q, convention="xyzw", xp=jnp)
     if rep == "sixd":
         return SO3.to_sixd(q, xp=jnp)
+    if rep == "hinge":
+        return jnp.array([[0.1], [-0.2]])
     raise ValueError(rep)
 
 
@@ -143,7 +145,20 @@ def test_jit_to_sixd():
 @pytest.mark.parametrize("source,target", _CONV_PAIRS, ids=[f"{s}->{t}" for s, t in _CONV_PAIRS])
 def test_jit_so3_pairwise_conversions(source, target):
     fn = getattr(SO3.conversions, f"from_{source}_to_{target}")
-    if source == "euler" and target == "quat":
+    axes = jnp.array([0.0, 0.0, 1.0])
+    if source == "hinge" and target == "euler":
+        compiled = jax.jit(lambda x: fn(x, axes, convention="XYZ", xp=jnp))
+    elif source == "hinge" and target == "quat":
+        compiled = jax.jit(lambda x: fn(x, axes, convention="xyzw", xp=jnp))
+    elif source == "hinge":
+        compiled = jax.jit(lambda x: fn(x, axes, xp=jnp))
+    elif target == "hinge" and source == "euler":
+        compiled = jax.jit(lambda x: fn(x, axes, convention="XYZ", xp=jnp))
+    elif target == "hinge" and source == "quat":
+        compiled = jax.jit(lambda x: fn(x, axes, convention="xyzw", xp=jnp))
+    elif target == "hinge":
+        compiled = jax.jit(lambda x: fn(x, axes, xp=jnp))
+    elif source == "euler" and target == "quat":
         compiled = jax.jit(lambda x: fn(x, src_convention="XYZ", dst_convention="xyzw", xp=jnp))
     elif source == "quat" and target == "euler":
         compiled = jax.jit(lambda x: fn(x, src_convention="xyzw", dst_convention="XYZ", xp=jnp))

--- a/tests/test_so3_hinge.py
+++ b/tests/test_so3_hinge.py
@@ -87,3 +87,37 @@ def test_hinge_helpers_accept_quaternion_convention():
     recovered = SO3.to_hinge(rotation, axes, convention="xyzw")
 
     assert np.allclose(recovered, angles, atol=ATOL[32])
+
+
+@pytest.mark.parametrize("backend", TEST_BACKENDS)
+@pytest.mark.parametrize("precision", TEST_PRECISIONS)
+@pytest.mark.parametrize("pass_xp", TEST_PASS_XP)
+def test_pairwise_from_hinge_to_axis_angle_is_direct(backend, precision, pass_xp):
+    xp = get_namespace_by_name(backend)
+    angles = xp.asarray(np.array([[0.1], [-0.2], [0.3]], dtype=f"float{precision}"))
+    axes = xp.asarray(np.array([[0.0, 0.0, 2.0]], dtype=f"float{precision}"))
+    xp_kwargs = get_xp_kwargs(backend, pass_xp)
+
+    result = SO3.conversions.from_hinge_to_axis_angle(angles, axes, **xp_kwargs)
+    expected = angles * axes
+
+    assert result.dtype == expected.dtype
+    assert result.shape == (3, 3)
+    assert np.allclose(np.array(result), np.array(expected), atol=ATOL[precision])
+
+
+@pytest.mark.parametrize("backend", TEST_BACKENDS)
+@pytest.mark.parametrize("precision", TEST_PRECISIONS)
+@pytest.mark.parametrize("pass_xp", TEST_PASS_XP)
+def test_pairwise_from_axis_angle_to_hinge_is_projection(backend, precision, pass_xp):
+    xp = get_namespace_by_name(backend)
+    axis_angle = xp.asarray(np.array([[0.2, 0.3, 0.0], [-0.4, 0.1, 0.0]], dtype=f"float{precision}"))
+    axes = xp.asarray(np.array([2.0, 0.0, 0.0], dtype=f"float{precision}"))
+    xp_kwargs = get_xp_kwargs(backend, pass_xp)
+
+    result = SO3.conversions.from_axis_angle_to_hinge(axis_angle, axes, **xp_kwargs)
+    expected = xp.asarray(np.array([[0.1], [-0.2]], dtype=f"float{precision}"))
+
+    assert result.dtype == expected.dtype
+    assert result.shape == expected.shape
+    assert np.allclose(np.array(result), np.array(expected), atol=ATOL[precision])

--- a/tests/test_so3_pairwise_conversions.py
+++ b/tests/test_so3_pairwise_conversions.py
@@ -15,6 +15,11 @@ _EULER_CONVENTIONS = ["ZYX", "XYZ", "ZXZ"]
 _QUAT_CONVENTION = "xyzw"
 
 
+def _make_hinge_axes(backend):
+    xp = get_namespace_by_name(backend)
+    return xp.asarray(np.array([0.0, 0.0, 2.0], dtype=np.float32))
+
+
 def _make_input(source: str, batch_dims, backend, precision=32, convention="ZYX", quat_convention="wxyz"):
     """Return a sample array in the given representation."""
     q = random_quaternion(batch_dims=batch_dims, backend=backend, precision=precision)
@@ -22,6 +27,9 @@ def _make_input(source: str, batch_dims, backend, precision=32, convention="ZYX"
         return SO3.to_axis_angle(q)
     if source == "euler":
         return SO3.to_euler(q, convention=convention)
+    if source == "hinge":
+        xp = get_namespace_by_name(backend)
+        return xp.asarray(np.full(batch_dims + (1,), 0.2, dtype=f"float{precision}"))
     if source == "matrix":
         xp = get_namespace_by_name(backend)
         rotmat = SO3.to_rotmat(q)
@@ -36,12 +44,14 @@ def _make_input(source: str, batch_dims, backend, precision=32, convention="ZYX"
     raise ValueError(source)
 
 
-def _manual_convert(x, source, target, src_convention="ZYX", dst_convention="ZYX"):
+def _manual_convert(x, source, target, axes=None, src_convention="ZYX", dst_convention="ZYX"):
     """Convert via the two-step from/to primitive path (the reference)."""
     if source == "axis_angle":
         q = SO3.from_axis_angle(x)
     elif source == "euler":
         q = SO3.from_euler(x, convention=src_convention)
+    elif source == "hinge":
+        q = SO3.from_hinge(x, axes)
     elif source == "matrix":
         q = SO3.from_matrix(x)
     elif source == "rotmat":
@@ -57,6 +67,8 @@ def _manual_convert(x, source, target, src_convention="ZYX", dst_convention="ZYX
         return SO3.to_axis_angle(q)
     if target == "euler":
         return SO3.to_euler(q, convention=dst_convention)
+    if target == "hinge":
+        return SO3.to_hinge(q, axes)
     if target == "rotmat":
         return SO3.to_rotmat(q)
     if target == "quat":
@@ -70,8 +82,8 @@ def _manual_convert(x, source, target, src_convention="ZYX", dst_convention="ZYX
 # All supported source-target pairs
 # ---------------------------------------------------------------------------
 
-_SOURCE_REPS = ["axis_angle", "euler", "matrix", "rotmat", "quat", "sixd"]
-_TARGET_REPS = ["axis_angle", "euler", "rotmat", "quat", "sixd"]
+_SOURCE_REPS = ["axis_angle", "euler", "hinge", "matrix", "rotmat", "quat", "sixd"]
+_TARGET_REPS = ["axis_angle", "euler", "hinge", "rotmat", "quat", "sixd"]
 _PAIRS = [(s, t) for s in _SOURCE_REPS for t in _TARGET_REPS if s != t]
 
 
@@ -94,10 +106,23 @@ def test_equivalence(pair, backend, batch_dims, pass_xp):
     xp_kwargs = get_xp_kwargs(backend, pass_xp)
     src_convention = _QUAT_CONVENTION if source == "quat" else "XYZ"
     dst_convention = _QUAT_CONVENTION if target == "quat" else "XYZ"
+    axes = _make_hinge_axes(backend)
     x = _make_input(source, batch_dims, backend, convention="XYZ", quat_convention=src_convention)
 
     fn = _get_conv_fn(source, target)
-    if source == "euler" and target == "euler":
+    if source == "hinge" and target == "euler":
+        result = fn(x, axes, convention=dst_convention, **xp_kwargs)
+    elif source == "hinge" and target == "quat":
+        result = fn(x, axes, convention=dst_convention, **xp_kwargs)
+    elif source == "hinge":
+        result = fn(x, axes, **xp_kwargs)
+    elif target == "hinge" and source == "euler":
+        result = fn(x, axes, convention=src_convention, **xp_kwargs)
+    elif target == "hinge" and source == "quat":
+        result = fn(x, axes, convention=src_convention, **xp_kwargs)
+    elif target == "hinge":
+        result = fn(x, axes, **xp_kwargs)
+    elif source == "euler" and target == "euler":
         result = fn(x, src_convention=src_convention, dst_convention=dst_convention, **xp_kwargs)
     elif source == "euler" and target == "quat":
         result = fn(x, src_convention=src_convention, dst_convention=dst_convention, **xp_kwargs)
@@ -115,7 +140,7 @@ def test_equivalence(pair, backend, batch_dims, pass_xp):
         result = fn(x, convention=src_convention, **xp_kwargs)
     else:
         result = fn(x, **xp_kwargs)
-    expected = _manual_convert(x, source, target, src_convention=src_convention, dst_convention=dst_convention)
+    expected = _manual_convert(x, source, target, axes=axes, src_convention=src_convention, dst_convention=dst_convention)
 
     result_np = np.array(result)
     expected_np = np.array(expected)

--- a/tests/test_torch_compile.py
+++ b/tests/test_torch_compile.py
@@ -40,8 +40,8 @@ def _conv_input(rep: str):
 
 
 _CONV_REPS = ["axis_angle", "euler", "matrix", "rotmat", "quat", "sixd"]
-_PAIRWISE_SOURCE_REPS = ["axis_angle", "euler", "matrix", "rotmat", "quat", "sixd"]
-_PAIRWISE_TARGET_REPS = ["axis_angle", "euler", "rotmat", "quat", "sixd"]
+_PAIRWISE_SOURCE_REPS = ["axis_angle", "euler", "hinge", "matrix", "rotmat", "quat", "sixd"]
+_PAIRWISE_TARGET_REPS = ["axis_angle", "euler", "hinge", "rotmat", "quat", "sixd"]
 _CONV_PAIRS = [(s, t) for s in _PAIRWISE_SOURCE_REPS for t in _PAIRWISE_TARGET_REPS if s != t]
 _DYNAMIC_CONV_CASES = [
     ("axis_angle", "rotmat"),
@@ -69,6 +69,8 @@ def _pairwise_input(rep: str):
         return SO3.to_quat(q, convention="xyzw", xp=torch)
     if rep == "sixd":
         return SO3.to_sixd(q, xp=torch)
+    if rep == "hinge":
+        return torch.tensor([[0.1], [-0.2]])
     raise ValueError(rep)
 
 
@@ -185,8 +187,33 @@ def test_compile_to_sixd():
 def test_compile_so3_pairwise_conversions(source, target):
     torch._dynamo.reset()
     fn = getattr(SO3.conversions, f"from_{source}_to_{target}")
+    axes = torch.tensor([0.0, 0.0, 1.0])
 
-    if source == "euler" and target == "quat":
+    if source == "hinge" and target == "euler":
+
+        def f(x):
+            return fn(x, axes, convention="XYZ", xp=torch)
+    elif source == "hinge" and target == "quat":
+
+        def f(x):
+            return fn(x, axes, convention="xyzw", xp=torch)
+    elif source == "hinge":
+
+        def f(x):
+            return fn(x, axes, xp=torch)
+    elif target == "hinge" and source == "euler":
+
+        def f(x):
+            return fn(x, axes, convention="XYZ", xp=torch)
+    elif target == "hinge" and source == "quat":
+
+        def f(x):
+            return fn(x, axes, convention="xyzw", xp=torch)
+    elif target == "hinge":
+
+        def f(x):
+            return fn(x, axes, xp=torch)
+    elif source == "euler" and target == "quat":
 
         def f(x):
             return fn(x, src_convention="XYZ", dst_convention="xyzw", xp=torch)

--- a/uv.lock
+++ b/uv.lock
@@ -379,7 +379,7 @@ wheels = [
 
 [[package]]
 name = "nanomanifold"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "jaxtyping", version = "0.3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Adds first-class `hinge` support to `SO3.conversions` while keeping the top-level hinge API unchanged.

- Adds optimized pairwise conversions from hinge to axis-angle, Euler, rotmat, quat, and sixd.
- Adds inverse hinge projections from axis-angle, Euler, matrix, rotmat, quat, and sixd.
- Documents hinge in the pairwise conversion table and expands the standard pairwise/JAX/Torch coverage.
- Bumps the package version to `0.7.1`.

The direct hinge paths avoid unnecessary quaternion round trips: `from_hinge_to_axis_angle` computes `angles * axes`, and `from_axis_angle_to_hinge` performs the projection directly.

## Validation

- `uv run ruff check .`
- `uv run pytest`