### PR TITLE
Fix Davenport projection for 180-degree rotations

### DIFF
--- a/src/nanomanifold/SO3/primitives/rotmat.py
+++ b/src/nanomanifold/SO3/primitives/rotmat.py
@@ -77,7 +77,9 @@ def _project_matrix_to_rotmat_davenport(matrix: Float[Any, "... 3 3"], xp, *, st
 
     one = xp.ones_like(trace)
     zero = xp.zeros_like(trace)
-    quat = xp.stack([one, zero, zero, zero], axis=-1)
+    diagonal = xp.stack([k[..., i, i] for i in range(4)], axis=-1)
+    seed = xp.argmax(diagonal, axis=-1)
+    quat = xp.stack([xp.where(seed == i, one, zero) for i in range(4)], axis=-1)
 
     for _ in range(steps):
         quat = xp.matmul(k, quat[..., None])[..., 0]


### PR DESCRIPTION
## Summary

Seed Davenport power iteration from the largest diagonal component of `K`, so exact 180-degree rotations are no longer orthogonal to the initial quaternion.

This is the independent Davenport correctness issue found while investigating #37. It does not change the default projection mode or address the SVD gradient behavior.

## Verification

- `uv run pytest -q` — 12,835 passed, 70 skipped
- lint, formatting, and type checks
- 100 random half-turns on NumPy, PyTorch, and JAX

No tests are added in this PR.