### PR TITLE
Fix Davenport projection for generic matrices

### DIFF
--- a/src/nanomanifold/SO3/primitives/rotmat.py
+++ b/src/nanomanifold/SO3/primitives/rotmat.py
@@ -58,7 +58,7 @@ def _project_matrix_to_rotmat_svd(matrix: Float[Any, "... 3 3"], xp) -> Float[An
     return xp.matmul(u, xp.matmul(correction, vh))
 
 
-def _project_matrix_to_rotmat_davenport(matrix: Float[Any, "... 3 3"], xp, *, steps: int = 20, eps: float = 1e-7) -> Float[Any, "... 3 3"]:
+def _project_matrix_to_rotmat_davenport(matrix: Float[Any, "... 3 3"], xp, *, steps: int = 15, eps: float = 1e-7) -> Float[Any, "... 3 3"]:
     m00, m01, m02 = matrix[..., 0, 0], matrix[..., 0, 1], matrix[..., 0, 2]
     m10, m11, m12 = matrix[..., 1, 0], matrix[..., 1, 1], matrix[..., 1, 2]
     m20, m21, m22 = matrix[..., 2, 0], matrix[..., 2, 1], matrix[..., 2, 2]
@@ -77,15 +77,27 @@ def _project_matrix_to_rotmat_davenport(matrix: Float[Any, "... 3 3"], xp, *, st
 
     one = xp.ones_like(trace)
     zero = xp.zeros_like(trace)
-    diagonal = xp.stack([k[..., i, i] for i in range(4)], axis=-1)
-    seed = xp.argmax(diagonal, axis=-1)
-    quat = xp.stack([xp.where(seed == i, one, zero) for i in range(4)], axis=-1)
+    identity = xp.stack(
+        [
+            xp.stack([one, zero, zero, zero], axis=-1),
+            xp.stack([zero, one, zero, zero], axis=-1),
+            xp.stack([zero, zero, one, zero], axis=-1),
+            xp.stack([zero, zero, zero, one], axis=-1),
+        ],
+        axis=-2,
+    )
 
+    # Shift K so its largest algebraic eigenvalue also has the largest magnitude,
+    # then square from the full eigenspace to avoid dependence on a single seed.
+    projector = k + (xp.linalg.norm(k, axis=(-2, -1), keepdims=True) + eps) * identity
     for _ in range(steps):
-        quat = xp.matmul(k, quat[..., None])[..., 0]
-        quat = quat / (xp.linalg.norm(quat, axis=-1, keepdims=True) + eps)
+        projector = projector / (xp.linalg.norm(projector, axis=(-2, -1), keepdims=True) + eps)
+        projector = xp.matmul(projector, projector)
 
-    quat = xp.where(quat[..., :1] < 0, -quat, quat)
+    diagonal = xp.stack([projector[..., i, i] for i in range(4)], axis=-1)
+    column = xp.argmax(diagonal, axis=-1)
+    seed = xp.stack([xp.where(column == i, one, zero) for i in range(4)], axis=-1)
+    quat = xp.matmul(projector, seed[..., None])[..., 0]
     return to_rotmat(quat, xp=xp)
 
 

--- a/tests/test_so3_conversions_matrix.py
+++ b/tests/test_so3_conversions_matrix.py
@@ -117,3 +117,12 @@ def test_from_matrix_normalize_projects_to_so3(backend, pass_xp, mode):
 def test_from_matrix_rejects_unknown_projection_mode():
     with pytest.raises(ValueError, match="Unsupported projection mode"):
         SO3.from_matrix(np.eye(3), mode="bad")
+
+
+def test_davenport_projects_orientation_reversing_matrix():
+    matrix = np.array([[1.0, 0.2, 0.1], [0.3, 2.0, -0.4], [0.2, 0.1, -1.0]])
+
+    actual = SO3.conversions.from_matrix_to_rotmat(matrix, mode="davenport")
+    expected = SO3.conversions.from_matrix_to_rotmat(matrix, mode="svd")
+
+    assert np.allclose(actual, expected, atol=ATOL[64])


### PR DESCRIPTION
## Summary

- shift Davenport’s `K` matrix so the largest algebraic eigenvalue also has the largest magnitude
- iterate from the full eigenspace, removing dependence on a potentially orthogonal quaternion seed
- use repeated squaring for fast, backend-neutral convergence
- cover the determinant-negative case that previously converged to the wrong rotation

This follows #38 and fixes the broader projection issue found while investigating #37. It does not change the default SVD mode.

## Verification

- `uv run pytest -q` — 12,836 passed, 70 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uvx ty check`
- PyTorch gradcheck at and near identity
- JAX JIT and PyTorch compile suites
- comparison with SVD across 20,000 random matrices
- 100 random half-turns on NumPy, PyTorch, and JAX